### PR TITLE
fix(mythicmobs): 解决技能伤害与 MythicMobs兼容问题

### DIFF
--- a/src/main/kotlin/com/skillw/fightsystem/internal/feature/compat/mythicmobs/common/AttackV.kt
+++ b/src/main/kotlin/com/skillw/fightsystem/internal/feature/compat/mythicmobs/common/AttackV.kt
@@ -18,6 +18,7 @@ import taboolib.common.platform.Awake
 import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.SubscribeEvent
 import taboolib.platform.util.attacker
+import taboolib.platform.util.hasMeta
 
 object AttackV {
 
@@ -51,6 +52,7 @@ object AttackV {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun event(event: EntityDamageByEntityEvent) {
         if (event.isCancelled) return
+        if (event.entity.hasMeta("skill-damage")) return
         if (!isMythMobV) return
         if (!FSConfig.isFightEnable) return
         if (!event.attacker?.isMythicMob()!!) return

--- a/src/main/kotlin/com/skillw/fightsystem/internal/feature/compat/mythicmobs/legacy/AttackIV.kt
+++ b/src/main/kotlin/com/skillw/fightsystem/internal/feature/compat/mythicmobs/legacy/AttackIV.kt
@@ -19,6 +19,7 @@ import taboolib.common.platform.Awake
 import taboolib.common.platform.event.EventPriority
 import taboolib.common.platform.event.SubscribeEvent
 import taboolib.platform.util.attacker
+import taboolib.platform.util.hasMeta
 
 object AttackIV {
 
@@ -58,6 +59,7 @@ object AttackIV {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     fun event(event: EntityDamageByEntityEvent) {
         if (event.isCancelled) return
+        if (event.entity.hasMeta("skill-damage")) return
         if (!isMythMobIV) return
         if (!FSConfig.isFightEnable) return
         if (!event.attacker?.isMythicMob()!!) return


### PR DESCRIPTION
- 在 AttackIV 和 AttackV 类中添加检查实体是否具有 "skill-damage"元数据的逻辑
- 如果实体具有 "skill-damage" 元数据，则忽略伤害事件，避免技能伤害触发 MythicMobs 相关逻辑